### PR TITLE
Add posts_per_page = -1 to get_posts within category loop

### DIFF
--- a/web/app/themes/foods-for-life/functions.php
+++ b/web/app/themes/foods-for-life/functions.php
@@ -17,7 +17,8 @@ function get_catering_posts() {
 
     // For each category in the catering category, fetch its posts
     foreach ($categories as $category_key => $category) {
-        $posts = get_posts(array( 'category' => $category->cat_ID, ));
+        // Ensure that we return all posts for this category
+        $posts = get_posts(array( 'category' => $category->cat_ID, 'posts_per_page' => -1 ));
 
         // For each post, fetch its custom fields
         foreach ($posts as $post_key => $post) {


### PR DESCRIPTION
Resolves #7.

As we're not actually looping through blog posts, and we know that the
most number of items we're likely to return will be in the order of
tens, not hundreds, ensure that we return ALL posts in the given
category.
